### PR TITLE
Spot requests

### DIFF
--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -48,19 +48,19 @@
 <!--       with edit button on it -->
     <div class="each-spot">
       <% @event.spots.each do |spot|%>
-        <p><strong><%= spot.role %></strong></p>
+        <p><strong><%= spot.category %> || <%= spot.role %></strong></p>
         <% if spot.requests.empty? || spot.requests.where.not(status: "confirmed").present? %>
           <p>Status: Empty 🤷🏼‍♂️</p>
         <% else %>
           <p>Status: Spot filled 🙏</p>
         <% end %>
-        <p>Category: <%= spot.category %></p>
-        <p>Role: <%= spot.role %></p>
         <p>Description: <%= spot.description %></p>
         <% if spot.requests.where(status: "confirmed").present? %>
           <p><b>Spot has been filled by:</b></p>
-          <p><%= spot.requests.first.user.first_name %></p>
+          <div class="rounded-circle" style="background-image: linear-gradient(rgba(0,0,0,0.3), rgba(0,0,0,0.2)), url('<%= cl_image_path spot.requests.first.user.profile_photo, height: 300, width: 400, crop: :fill %>')">
+          <p>🌟<%= link_to "#{spot.requests.first.user.first_name}", spot_creative_path(spot, spot.requests.first.user)%> 🌟</p>
           <p><%= spot.requests.first.user.skill %></p>
+          </div>
         <% else %>
           <p><b>Blank</b></p>
         <% end %>
@@ -80,7 +80,7 @@
       <% @event.spots.each do |spot| %>
         <% notifications = spot.requests.where(status: :pending) %> <%# Need to change to "pending" %>
         <% notifications.each_with_index do |notification, index| %>
-          <p><%= index + 1 %>. "Link to creative show here" <%= notification.status %>
+          <p><%= index + 1 %>. <%= link_to "#{spot.requests.first.user.first_name}", spot_creative_path(spot, spot.requests.first.user)%> <%= notification.status %>
           <p>Message: <%= notification.note %></p>
           <%= simple_form_for [@spot, notification], url: spot_request_path(spot, notification)  do |f| %>
               <%= f.input :status, collection: Request.statuses %>


### PR DESCRIPTION
List of what I've done
 
- Corrected statuses so that spot says confirmed or not at right times
- When confirmed, details of creative appear with profile picture as a background photo
- Also, link to creative profile page 
- If not confirmed, then spot left blank - **could do with having a blank avatar or something here**

- Got rid of notifications within spots and moved to separate box at the bottom
- Made link to creative show page on each request
- **Still need to tidy up and organise this requests section properly**