### PR TITLE
remove opacity on back btn + fixed photos

### DIFF
--- a/app/assets/stylesheets/pages/_spot_user_show.scss
+++ b/app/assets/stylesheets/pages/_spot_user_show.scss
@@ -94,6 +94,7 @@ text-align: left;
   text-align: center;
   justify-content: space-between;
   position: absolute;
+  opacity: 1 !important;
   // top: 35px;
   // left: 50px;
   z-index: 2;
@@ -213,5 +214,6 @@ text-align: left;
     top: -10px;
     right: 19px;
     font-size: xx-large;
+    opacity: 1;
     }
 

--- a/app/views/creatives/show.html.erb
+++ b/app/views/creatives/show.html.erb
@@ -110,7 +110,9 @@
           <a href="#"><img class="d-flex justify-content-center align-items-center h-100" src="https://res.cloudinary.com/dqnhjr33l/image/upload/v1567611403/profile%20square/nrgxv9tx6mh6etgbxqvf.png" alt=""></a>
 
           <% @user.photos.each do |photo| %>
-            <a href="#"><%= cl_image_tag photo.photo %></a>
+            <a href="#">
+              <div style="background-image: url(<%= cl_image_path photo.photo %>);height: 100%; background-size: cover; background-position: center"></div>
+            </a>
           <% end %>
         </div>
       </div>


### PR DESCRIPTION

<img width="1280" alt="Screenshot 2019-09-05 at 18 30 44" src="https://user-images.githubusercontent.com/44376370/64360717-4a395600-d00b-11e9-8922-de68cd84eca4.png">



Removed opacity on event show and made pictures centered 

MAKE SUREE WE PICK SQUARE PIICS FOR DEMO